### PR TITLE
Remove typescript from runtime dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@creditkarma/consul-client",
-    "version": "0.8.6",
+    "version": "0.8.7",
     "description": "A client for Hashicorp Consul written in TypeScript",
     "main": "dist/main/index.js",
     "types": "dist/main/index.d.ts",
@@ -21,7 +21,6 @@
         "docker:kill": "docker-compose kill consul",
         "prebuild": "npm run clean",
         "build": "npm run lint && npm run format && tsc",
-	"postinstall": "./node_modules/typescript/bin/tsc",
         "pretest": "npm run docker:kill && npm run build && npm run docker",
         "posttest": "npm run docker:kill && rimraf consuldata/*",
         "test": "wait-on --timeout 20000 http://localhost:8500 && npm run lint && npm run test:unit && npm run test:integration",
@@ -46,7 +45,8 @@
         "eslint-plugin-prettier": "^3.1.0",
         "prettier": "^1.18.2",
         "rimraf": "^2.6.3",
-        "wait-on": "^3.2.0"
+        "wait-on": "^3.2.0",
+        "typescript": "^3.8.0-dev.20191203"
     },
     "dependencies": {
         "@types/lodash": "^4.14.136",
@@ -54,7 +54,6 @@
         "@types/request-promise-native": "^1.0.16",
         "lodash": "^4.17.15",
         "request": "^2.88.0",
-        "request-promise-native": "^1.0.7",
-	"typescript": "3.5.x"
+        "request-promise-native": "^1.0.7"
     }
 }


### PR DESCRIPTION
@agamdua @matt-casey

Currently, typescript is included here and then compiled on post install. Instead, I want to upload the compiled dist as an artifact, and use that as the module.

This will save us about 40MB in eden since this module comes with it's own installation of typescript currently